### PR TITLE
fix sample calc in library, add getTradeDiffs

### DIFF
--- a/contracts/VelodromeLibrary.sol
+++ b/contracts/VelodromeLibrary.sol
@@ -27,36 +27,63 @@ contract VelodromeLibrary {
         address t0;
     }
 
-    function _f(uint x0, uint y) internal pure returns (uint) {
-        return x0*(y*y/1e18*y/1e18)/1e18+(x0*x0/1e18*x0/1e18)*y/1e18;
+    function _f(uint x0, uint y) internal pure returns (uint256) {
+        uint256 _a = (x0 * y) / 1e18;
+        uint256 _b = ((x0 * x0) / 1e18 + (y * y) / 1e18);
+        return (_a * _b) / 1e18;
     }
 
-    function _d(uint x0, uint y) internal pure returns (uint) {
-        return 3*x0*(y*y/1e18)/1e18+(x0*x0/1e18*x0/1e18);
+    function _d(uint256 x0, uint256 y) internal pure returns (uint256) {
+        return (3 * x0 * ((y * y) / 1e18)) / 1e18 + ((((x0 * x0) / 1e18) * x0) / 1e18);
     }
 
-    function _get_y(uint x0, uint xy, uint y) internal pure returns (uint) {
-        for (uint i = 0; i < 255; i++) {
-            uint y_prev = y;
-            uint k = _f(x0, y);
+    function _get_y(
+        uint256 x0,
+        uint256 xy,
+        uint256 y,
+        bool stable,
+        uint256 decimals0,
+        uint256 decimals1
+    ) internal pure returns (uint256) {
+        for (uint256 i = 0; i < 255; i++) {
+            uint256 k = _f(x0, y);
             if (k < xy) {
-                uint dy = (xy - k)*1e18/_d(x0, y);
+                // there are two cases where dy == 0
+                // case 1: The y is converged and we find the correct answer
+                // case 2: _d(x0, y) is too large compare to (xy - k) and the rounding error
+                //         screwed us.
+                //         In this case, we need to increase y by 1
+                uint256 dy = ((xy - k) * 1e18) / _d(x0, y);
+                if (dy == 0) {
+                    if (k == xy) {
+                        // We found the correct answer. Return y
+                        return y;
+                    }
+                    if (_k(x0, y + 1, stable, decimals0, decimals1) > xy) {
+                        // If _k(x0, y + 1) > xy, then we are close to the correct answer.
+                        // There's no closer answer than y + 1
+                        return y + 1;
+                    }
+                    dy = 1;
+                }
                 y = y + dy;
             } else {
-                uint dy = (k - xy)*1e18/_d(x0, y);
+                uint256 dy = ((k - xy) * 1e18) / _d(x0, y);
+                if (dy == 0) {
+                    if (k == xy || _f(x0, y - 1) < xy) {
+                        // Likewise, if k == xy, we found the correct answer.
+                        // If _f(x0, y - 1) < xy, then we are close to the correct answer.
+                        // There's no closer answer than "y"
+                        // It's worth mentioning that we need to find y where f(x0, y) >= xy
+                        // As a result, we can't return y - 1 even it's closer to the correct answer
+                        return y;
+                    }
+                    dy = 1;
+                }
                 y = y - dy;
             }
-            if (y > y_prev) {
-                if (y - y_prev <= 1) {
-                    return y;
-                }
-            } else {
-                if (y_prev - y <= 1) {
-                    return y;
-                }
-            }
         }
-        return y;
+        revert("!y");
     }
 
     function getTradeDiffs(uint[] memory amountIn, address[] memory tokenIn, address[] memory tokenOut, bool[] memory stable) external view returns (uint[] memory a, uint[] memory b) {
@@ -121,7 +148,7 @@ contract VelodromeLibrary {
             _reserve1 = _reserve1 * 1e18 / decimals1;
             (uint reserveA, uint reserveB) = tokenIn == token0 ? (_reserve0, _reserve1) : (_reserve1, _reserve0);
             amountIn = tokenIn == token0 ? amountIn * 1e18 / decimals0 : amountIn * 1e18 / decimals1;
-            uint y = reserveB - _get_y(amountIn+reserveA, xy, reserveB);
+            uint y = reserveB - _get_y(amountIn+reserveA, xy, reserveB, stable, decimals0, decimals1);
             return y * (tokenIn == token0 ? decimals1 : decimals0) / 1e18;
         } else {
             (uint reserveA, uint reserveB, uint decimalsA, uint decimalsB) = tokenIn == token0 ? (_reserve0, _reserve1, decimals0, decimals1) : (_reserve1, _reserve0, decimals1, decimals0);


### PR DESCRIPTION
Deployed here https://optimistic.etherscan.io/address/0x82959edf06499c3c931c39ebca8737f0b5551bec and being used in nightride UI


Makes _getAmountOut account for differences in the amount of decimals for tokenA and tokenB, instead of just assuming both tokenA and tokenB have the same amount of decimals.

In getTradeDiff(uint,address,address,bool), sample was rounding to 0 in certain cases incorrectly, e.g. if the pool had 0.1 WBTC and 1e9 OptiDoge, sample would be 0, because 0.1 * 1e8 * 1e18/ ( 1e9 * 1e18 ) rounds to 0, so we just directly calculate the derivative instead for volatile pairs in getTradeDiff. 

Added a getTradeDiffs function just for convenience to be able to bundle many getTradeDiff calls at once (used by v2 UI).